### PR TITLE
remove warning c4828

### DIFF
--- a/include/Keycodes.h
+++ b/include/Keycodes.h
@@ -89,7 +89,7 @@ namespace irr
 		KEY_KEY_X            = 0x58,  // X key
 		KEY_KEY_Y            = 0x59,  // Y key
 		KEY_KEY_Z            = 0x5A,  // Z key
-		KEY_LWIN             = 0x5B,  // Left Windows key (Microsoft® Natural® keyboard)
+		KEY_LWIN             = 0x5B,  // Left Windows key (MicrosoftÂ® NaturalÂ® keyboard)
 		KEY_RWIN             = 0x5C,  // Right Windows key (Natural keyboard)
 		KEY_APPS             = 0x5D,  // Applications key (Natural keyboard)
 		KEY_SLEEP            = 0x5F,  // Computer Sleep key


### PR DESCRIPTION
in Unicode
®
U+00AE REGISTERED SIGN
