### PR TITLE
remove some _MSC_VER macro

### DIFF
--- a/include/irrTypes.h
+++ b/include/irrTypes.h
@@ -12,19 +12,11 @@ namespace irr
 
 //! 8 bit unsigned variable.
 /** This is a typedef for unsigned char, it ensures portability of the engine. */
-#if defined(_MSC_VER) || ((__BORLANDC__ >= 0x530) && !defined(__STRICT_ANSI__))
-typedef unsigned __int8		u8;
-#else
 typedef unsigned char		u8;
-#endif
 
 //! 8 bit signed variable.
 /** This is a typedef for signed char, it ensures portability of the engine. */
-#if defined(_MSC_VER) || ((__BORLANDC__ >= 0x530) && !defined(__STRICT_ANSI__))
-typedef __int8			s8;
-#else
 typedef signed char		s8;
-#endif
 
 //! 8 bit character variable.
 /** This is a typedef for char, it ensures portability of the engine. */
@@ -34,19 +26,11 @@ typedef char			c8;
 
 //! 16 bit unsigned variable.
 /** This is a typedef for unsigned short, it ensures portability of the engine. */
-#if defined(_MSC_VER) || ((__BORLANDC__ >= 0x530) && !defined(__STRICT_ANSI__))
-typedef unsigned __int16	u16;
-#else
 typedef unsigned short		u16;
-#endif
 
 //! 16 bit signed variable.
 /** This is a typedef for signed short, it ensures portability of the engine. */
-#if defined(_MSC_VER) || ((__BORLANDC__ >= 0x530) && !defined(__STRICT_ANSI__))
-typedef __int16			s16;
-#else
 typedef signed short		s16;
-#endif
 
 //! 16 bit character variable.
 /** This is a typedef for wchar_t, it ensures portability of the engine. */
@@ -55,49 +39,21 @@ typedef wchar_t			c16;
 
 //! 32 bit unsigned variable.
 /** This is a typedef for unsigned int, it ensures portability of the engine. */
-#if defined(_MSC_VER) || ((__BORLANDC__ >= 0x530) && !defined(__STRICT_ANSI__))
-typedef unsigned __int32	u32;
-#else
 typedef unsigned int		u32;
-#endif
 
 //! 32 bit signed variable.
 /** This is a typedef for signed int, it ensures portability of the engine. */
-#if defined(_MSC_VER) || ((__BORLANDC__ >= 0x530) && !defined(__STRICT_ANSI__))
-typedef __int32			s32;
-#else
 typedef signed int		s32;
-#endif
 
 
 #ifdef __IRR_HAS_S64
 //! 64 bit unsigned variable.
 /** This is a typedef for 64bit uint, it ensures portability of the engine. */
-#if defined(_MSC_VER) || ((__BORLANDC__ >= 0x530) && !defined(__STRICT_ANSI__))
-typedef unsigned __int64			u64;
-#elif __GNUC__
-#if __WORDSIZE == 64
-typedef unsigned long int 			u64;
-#else
-__extension__ typedef unsigned long long	u64;
-#endif
-#else
 typedef unsigned long long			u64;
-#endif
 
 //! 64 bit signed variable.
 /** This is a typedef for 64bit int, it ensures portability of the engine. */
-#if defined(_MSC_VER) || ((__BORLANDC__ >= 0x530) && !defined(__STRICT_ANSI__))
-typedef __int64					s64;
-#elif __GNUC__
-#if __WORDSIZE == 64
-typedef long int 				s64;
-#else
-__extension__ typedef long long			s64;
-#endif
-#else
 typedef long long				s64;
-#endif
 #endif	// __IRR_HAS_S64
 
 
@@ -116,17 +72,6 @@ typedef double				f64;
 
 #include <wchar.h>
 #ifdef _IRR_WINDOWS_API_
-//! Defines for s{w,n}printf because these methods do not match the ISO C
-//! standard on Windows platforms, but it does on all others.
-//! These should be int snprintf(char *str, size_t size, const char *format, ...);
-//! and int swprintf(wchar_t *wcs, size_t maxlen, const wchar_t *format, ...);
-#if defined(_MSC_VER) && _MSC_VER > 1310 && !defined (_WIN32_WCE)
-#define swprintf swprintf_s
-#define snprintf sprintf_s
-#elif !defined(__CYGWIN__)
-#define swprintf _snwprintf
-#define snprintf _snprintf
-#endif
 
 // define the wchar_t type if not already built in.
 #ifdef _MSC_VER

--- a/source/Irrlicht/os.cpp
+++ b/source/Irrlicht/os.cpp
@@ -15,9 +15,6 @@
 	#include <stdlib.h>
 	#define bswap_16(X) _byteswap_ushort(X)
 	#define bswap_32(X) _byteswap_ulong(X)
-#if (_MSC_VER >= 1400)
-	#define localtime _localtime_s
-#endif
 #elif defined(_IRR_OSX_PLATFORM_)
 	#include <libkern/OSByteOrder.h>
 	#define bswap_16(X) OSReadSwapInt16(&X,0)


### PR DESCRIPTION
irrTypes.h
Last update: 2012/11/20

https://learn.microsoft.com/zh-tw/cpp/overview/compiler-versions?view=msvc-170
Visual Studio .NET 2002 （7.0）  1300
Visual Studio .NET 2003 （7.1）  1310
Visual Studio 2005 （8.0）  1400

https://learn.microsoft.com/zh-tw/cpp/cpp/data-type-ranges?view=msvc-170


My opinion:
It seems that the viewpoint about Visual Studio is based on the version before C++11.
The macros defined by `_MSC_VER` is outdated in 2024.

Macros like 
```cpp
#define swprintf swprintf_s
#define snprintf sprintf_s
```
are even harmful.

https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/sprintf-s-sprintf-s-l-swprintf-s-swprintf-s-l?view=msvc-170
> One main difference between sprintf_s and [sprintf](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/sprintf-sprintf-l-swprintf-swprintf-l-swprintf-l?view=msvc-170) is that sprintf_s checks the format string for valid formatting characters, whereas [sprintf](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/sprintf-sprintf-l-swprintf-swprintf-l-swprintf-l?view=msvc-170) only checks if the format string or buffer are NULL pointers. If either check fails, the invalid parameter handler is invoked, as described in [Parameter validation](https://learn.microsoft.com/en-us/cpp/c-runtime-library/parameter-validation?view=msvc-170). If execution is allowed to continue, the function returns -1 and sets errno to EINVAL.

> The other main difference between sprintf_s and [sprintf](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/sprintf-sprintf-l-swprintf-swprintf-l-swprintf-l?view=msvc-170) is that sprintf_s takes a length parameter specifying the size of the output buffer in characters. If the buffer is too small for the formatted text, including the terminating null, then the buffer is set to an empty string by placing a null character at buffer[0], and the invalid parameter handler is invoked. Unlike _snprintf, sprintf_s guarantees that the buffer will be null-terminated unless the buffer size is zero.

sprintf_s (MS version)
std::snprintf 
The definitions have lots of differences.
