### PR TITLE
use C++11 standard snprintf

### DIFF
--- a/include/irrTypes.h
+++ b/include/irrTypes.h
@@ -116,17 +116,6 @@ typedef double				f64;
 
 #include <wchar.h>
 #ifdef _IRR_WINDOWS_API_
-//! Defines for s{w,n}printf because these methods do not match the ISO C
-//! standard on Windows platforms, but it does on all others.
-//! These should be int snprintf(char *str, size_t size, const char *format, ...);
-//! and int swprintf(wchar_t *wcs, size_t maxlen, const wchar_t *format, ...);
-#if defined(_MSC_VER) && _MSC_VER > 1310 && !defined (_WIN32_WCE)
-#define swprintf swprintf_s
-#define snprintf sprintf_s
-#elif !defined(__CYGWIN__)
-#define swprintf _snwprintf
-#define snprintf _snprintf
-#endif
 
 // define the wchar_t type if not already built in.
 #ifdef _MSC_VER


### PR DESCRIPTION
https://en.cppreference.com/w/c/io/fprintf
int snprintf( char *restrict buffer, size_t bufsz, const char *restrict format, ... );
(since C99)

https://en.cppreference.com/w/cpp/io/c/fprintf
int snprintf( char* buffer, std::size_t buf_size, const char* format, ... );
(since C++11)

https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=msvc-170
Beginning with the UCRT in Visual Studio 2015 and Windows 10, `snprintf` is no longer identical to `_snprintf`. 
The snprintf behavior is now C99 standard conformant.

Visual Studio supports the standard version `snprintf` now, so redirecting `snprintf` to non-standard functions is unnecessary now.
It may cause many problems if we want to use `snprintf`.

Related:
https://github.com/Fluorohydride/ygopro/pull/2540/


