### PR TITLE
fix dereference nullptr & use uninitialized memory

### DIFF
--- a/include/SColor.h
+++ b/include/SColor.h
@@ -444,7 +444,7 @@ namespace video
 		}
 
 		//! color in A8R8G8B8 Format
-		u32 color;
+		u32 color{};
 	};
 
 

--- a/include/SMaterialLayer.h
+++ b/include/SMaterialLayer.h
@@ -72,8 +72,11 @@ namespace video
 		//! Destructor
 		~SMaterialLayer()
 		{
-			MatrixAllocator.destruct(TextureMatrix);
-			MatrixAllocator.deallocate(TextureMatrix); 
+			if(TextureMatrix)
+			{
+				MatrixAllocator.destruct(TextureMatrix);
+				MatrixAllocator.deallocate(TextureMatrix);
+			}
 		}
 
 		//! Assignment operator


### PR DESCRIPTION
https://sourceforge.net/p/irrlicht/code/5684/
2019-01-17
Merging [r5673](https://sourceforge.net/p/irrlicht/code/5673/) through [r5677](https://sourceforge.net/p/irrlicht/code/5677/) from trunk to ogl-es branch:

https://sourceforge.net/p/irrlicht/code/HEAD/tree/branches/releases/1.8/include/
irrlicht 1.8.5
雖然名義上是在2021更新
實際上在2019就已經被放棄
include目錄的檔案幾乎都是2012以後就不再更新

我認為堅守這個早在2019就過時的版本毫無意義
為了保護ygopro內存安全
這已經是最低限度需要的修正

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust