### PR TITLE
remove keyword register

### DIFF
--- a/source/Irrlicht/CColorConverter.cpp
+++ b/source/Irrlicht/CColorConverter.cpp
@@ -165,7 +165,7 @@ void CColorConverter::convert8BitTo32Bit(const u8* in, u8* out, s32 width, s32 h
 		out += lineWidth * height;
 
 	u32 x;
-	register u32 c;
+	u32 c;
 	for (u32 y=0; y < (u32) height; ++y)
 	{
 		if (flip)


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/keyword/register
Automatic storage duration specifier (deprecated). (until C++17)
The keyword is unused and reserved. (since C++17)

@mercury233 




