### PR TITLE
remove keyword register

### DIFF
--- a/source/Irrlicht/CColorConverter.cpp
+++ b/source/Irrlicht/CColorConverter.cpp
@@ -165,7 +165,7 @@ void CColorConverter::convert8BitTo32Bit(const u8* in, u8* out, s32 width, s32 h
 		out += lineWidth * height;
 
 	u32 x;
-	register u32 c;
+	u32 c;
 	for (u32 y=0; y < (u32) height; ++y)
 	{
 		if (flip)


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro/actions/runs/13889967817/job/38860153443
In file included from ../irrlicht/source/Irrlicht/CMY3DMeshFileLoader.cpp:21:
../irrlicht/source/Irrlicht/CMY3DHelper.h: In function ‘long unsigned int irr::core::process_comp(unsigned char*, int, unsigned char*, int)’:
../irrlicht/source/Irrlicht/CMY3DHelper.h:272:19: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]

../irrlicht/source/Irrlicht/CMY3DHelper.h: In function ‘void irr::core::flush_outbuf(unsigned char*, int)’:
../irrlicht/source/Irrlicht/CMY3DHelper.h:331:18: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]

GCC said that:
ISO C++17 does not allow ‘register’ storage class specifier 