### PR TITLE
apply r6691

### DIFF
--- a/source/Irrlicht/CD3D9ShaderMaterialRenderer.cpp
+++ b/source/Irrlicht/CD3D9ShaderMaterialRenderer.cpp
@@ -325,7 +325,7 @@ HRESULT CD3D9ShaderMaterialRenderer::stubD3DXAssembleShader(LPCSTR pSrcData,
 		if (!pFn && !LoadFailed)
 		{
 			// try to load dll
-			io::path strDllName = "d3dx9_";
+			irr::core::string<TCHAR> strDllName = "d3dx9_";
 			strDllName += (int)D3DX_SDK_VERSION;
 			strDllName += ".dll";
 
@@ -385,7 +385,7 @@ HRESULT CD3D9ShaderMaterialRenderer::stubD3DXAssembleShaderFromFile(LPCSTR pSrcF
 		if (!pFn && !LoadFailed)
 		{
 			// try to load dll
-			io::path strDllName = "d3dx9_";
+			irr::core::string<TCHAR> strDllName = "d3dx9_";
 			strDllName += (int)D3DX_SDK_VERSION;
 			strDllName += ".dll";
 
@@ -446,7 +446,7 @@ HRESULT CD3D9ShaderMaterialRenderer::stubD3DXCompileShader(LPCSTR pSrcData, UINT
 		if (!pFn && !LoadFailed)
 		{
 			// try to load dll
-			io::path strDllName = "d3dx9_";
+			irr::core::string<TCHAR> strDllName = "d3dx9_";
 			strDllName += (int)D3DX_SDK_VERSION;
 			strDllName += ".dll";
 
@@ -506,7 +506,7 @@ HRESULT CD3D9ShaderMaterialRenderer::stubD3DXCompileShaderFromFile(LPCSTR pSrcFi
 		if (!pFn && !LoadFailed)
 		{
 			// try to load dll
-			io::path strDllName = "d3dx9_";
+			irr::core::string<TCHAR> strDllName = "d3dx9_";
 			strDllName += (int)D3DX_SDK_VERSION;
 			strDllName += ".dll";
 

--- a/source/Irrlicht/CIrrDeviceWin32.cpp
+++ b/source/Irrlicht/CIrrDeviceWin32.cpp
@@ -1101,7 +1101,7 @@ CIrrDeviceWin32::CIrrDeviceWin32(const SIrrlichtCreationParameters& params)
 	// create the window if we need to and we do not use the null device
 	if (!CreationParams.WindowId && CreationParams.DriverType != video::EDT_NULL)
 	{
-		const fschar_t* ClassName = __TEXT("CIrrDeviceWin32");
+		const TCHAR* ClassName = __TEXT("CIrrDeviceWin32");
 
 		// Register Class
 		WNDCLASSEX wcex;
@@ -1472,7 +1472,7 @@ void CIrrDeviceWin32::closeDevice()
 	if (!ExternalWindow)
 	{
 		DestroyWindow(HWnd);
-		const fschar_t* ClassName = __TEXT("CIrrDeviceWin32");
+		const TCHAR* ClassName = __TEXT("CIrrDeviceWin32");
 		HINSTANCE hInstance = GetModuleHandle(0);
 		UnregisterClass(ClassName, hInstance);
 	}

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -89,7 +89,7 @@ bool COpenGLDriver::changeRenderContext(const SExposedVideoData& videoData, CIrr
 bool COpenGLDriver::initDriver(CIrrDeviceWin32* device)
 {
 	// Create a window to test antialiasing support
-	const fschar_t* ClassName = __TEXT("GLCIrrDeviceWin32");
+	const TCHAR* ClassName = __TEXT("GLCIrrDeviceWin32");
 	HINSTANCE lhInstance = GetModuleHandle(0);
 
 	// Register Class


### PR DESCRIPTION
> Allow compiling Irrlicht with Unicode characters set without _IRR_WCHAR_FILESYSTEM
A few strings used the Irrlicht filesystem character set in places where TCHAR is the nicer option.
https://sourceforge.net/p/irrlicht/code/6691/