### PR TITLE
fix EGET_LISTBOX_CHANGED event 

### DIFF
--- a/source/Irrlicht/CGUIListBox.cpp
+++ b/source/Irrlicht/CGUIListBox.cpp
@@ -326,6 +326,7 @@ bool CGUIListBox::OnEvent(const SEvent& event)
 
 				// find the selected item, starting at the current selection
 				s32 start = Selected;
+				s32 oldSelected = Selected;
 				// dont change selection if the key buffer matches the current item
 				if (Selected > -1 && KeyBuffer.size() > 1)
 				{
@@ -342,7 +343,7 @@ bool CGUIListBox::OnEvent(const SEvent& event)
 						if (KeyBuffer.equals_ignore_case(Items[current].text.subString(0,KeyBuffer.size())))
 						{
 							setSelected(current);
-							if (Parent && Selected != current && !Selecting && !MoveOverSelect)
+							if (Parent && oldSelected != current && !Selecting && !MoveOverSelect)
 							{
 								SEvent e;
 								e.EventType = EET_GUI_EVENT;
@@ -362,7 +363,7 @@ bool CGUIListBox::OnEvent(const SEvent& event)
 						if (KeyBuffer.equals_ignore_case(Items[current].text.subString(0,KeyBuffer.size())))
 						{
 							setSelected(current);
-							if (Parent && Selected != current && !Selecting && !MoveOverSelect)
+							if (Parent && oldSelected != current && !Selecting && !MoveOverSelect)
 							{
 								Selected = current;
 								SEvent e;

--- a/source/Irrlicht/CGUIListBox.cpp
+++ b/source/Irrlicht/CGUIListBox.cpp
@@ -341,6 +341,7 @@ bool CGUIListBox::OnEvent(const SEvent& event)
 					{
 						if (KeyBuffer.equals_ignore_case(Items[current].text.subString(0,KeyBuffer.size())))
 						{
+							setSelected(current);
 							if (Parent && Selected != current && !Selecting && !MoveOverSelect)
 							{
 								SEvent e;
@@ -350,7 +351,6 @@ bool CGUIListBox::OnEvent(const SEvent& event)
 								e.GUIEvent.EventType = EGET_LISTBOX_CHANGED;
 								Parent->OnEvent(e);
 							}
-							setSelected(current);
 							return true;
 						}
 					}
@@ -361,6 +361,7 @@ bool CGUIListBox::OnEvent(const SEvent& event)
 					{
 						if (KeyBuffer.equals_ignore_case(Items[current].text.subString(0,KeyBuffer.size())))
 						{
+							setSelected(current);
 							if (Parent && Selected != current && !Selecting && !MoveOverSelect)
 							{
 								Selected = current;
@@ -371,7 +372,6 @@ bool CGUIListBox::OnEvent(const SEvent& event)
 								e.GUIEvent.EventType = EGET_LISTBOX_CHANGED;
 								Parent->OnEvent(e);
 							}
-							setSelected(current);
 							return true;
 						}
 					}


### PR DESCRIPTION
Before
按下鍵盤的字母移動ListBox
EGET_LISTBOX_CHANGED在選取移動前觸發
因此EGET_LISTBOX_CHANGED抓到的選取項目是移動前的項目

After
按下鍵盤的字母移動ListBox
EGET_LISTBOX_CHANGED在選取移動後觸發

對於ygopro的影響：
replay列表按鍵盤的英文字母移動
顯示的yrp檔案資訊會是錯誤的項目

@mercury233 