### PR TITLE
set activation policy to Regular in macOS

### DIFF
--- a/source/Irrlicht/MacOSX/CIrrDeviceMacOSX.mm
+++ b/source/Irrlicht/MacOSX/CIrrDeviceMacOSX.mm
@@ -494,6 +494,7 @@ CIrrDeviceMacOSX::CIrrDeviceMacOSX(const SIrrlichtCreationParameters& param)
 		if(!CreationParams.WindowId) //load menus if standalone application
 		{
 			[[NSAutoreleasePool alloc] init];
+			[[NSApplication sharedApplication] setActivationPolicy:NSApplicationActivationPolicyRegular];
 			[[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
 			[NSApp setDelegate:(id<NSApplicationDelegate>)[[[AppDelegate alloc] initWithDevice:this] autorelease]];
 			[NSBundle loadNibNamed:@"MainMenu" owner:[NSApp delegate]];


### PR DESCRIPTION
This ensures the application appears in the Dock and has a menu bar. This was the default behavior, but recent updates of Xcode seem to have changed that.