### PR TITLE
apply r5827

### DIFF
--- a/source/Irrlicht/CIrrDeviceWin32.cpp
+++ b/source/Irrlicht/CIrrDeviceWin32.cpp
@@ -1504,7 +1504,7 @@ bool CIrrDeviceWin32::isWindowMinimized() const
 	plc.length=sizeof(WINDOWPLACEMENT);
 	bool ret=false;
 	if (GetWindowPlacement(HWnd,&plc))
-		ret=(plc.showCmd & SW_SHOWMINIMIZED)!=0;
+		ret = plc.showCmd == SW_SHOWMINIMIZED;
 	_IRR_IMPLEMENT_MANAGED_MARSHALLING_BUGFIX;
 	return ret;
 }


### PR DESCRIPTION
> Bugfix: IrrlichtDevice::isWindowMinimized no longer returns true when it's maximized on Windows.
SW_SHOWMINIMIZED isn't a bitflag as was probably assumed.
https://sourceforge.net/p/irrlicht/code/5827/

https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow

`SW_SHOWNORMAL` / `SW_NORMAL` : 1
`SW_SHOWMINIMIZED`  : 2
`SW_SHOWMAXIMIZED` / `SW_MAXIMIZE` : 3