### PR TITLE
Remove typename from xmlChar constructors declaration

### DIFF
--- a/include/irrXML.h
+++ b/include/irrXML.h
@@ -371,9 +371,9 @@ namespace io
 	struct xmlChar
 	{
 		T c;
-		xmlChar<T>() {}
-		xmlChar<T>(char in) : c(static_cast<T>(in)) {}
-		xmlChar<T>(wchar_t in) : c(static_cast<T>(in)) {}
+		xmlChar() {}
+		xmlChar(char in) : c(static_cast<T>(in)) {}
+		xmlChar(wchar_t in) : c(static_cast<T>(in)) {}
 #if defined(__BORLANDC__)
 		// Note - removing explicit for borland was to get it to even compile.
 		// There haven't been any kind of tests for that besides that.
@@ -382,10 +382,10 @@ namespace io
 		xmlChar<T>(unsigned int in) : c(static_cast<T>(in)) {}
 		xmlChar<T>(unsigned long in) : c(static_cast<T>(in)) {}
 #else 
-		explicit xmlChar<T>(unsigned char in) : c(static_cast<T>(in)) {}
-		explicit xmlChar<T>(unsigned short in) : c(static_cast<T>(in)) {}
-		explicit xmlChar<T>(unsigned int in) : c(static_cast<T>(in)) {}
-		explicit xmlChar<T>(unsigned long in) : c(static_cast<T>(in)) {}
+		explicit xmlChar(unsigned char in) : c(static_cast<T>(in)) {}
+		explicit xmlChar(unsigned short in) : c(static_cast<T>(in)) {}
+		explicit xmlChar(unsigned int in) : c(static_cast<T>(in)) {}
+		explicit xmlChar(unsigned long in) : c(static_cast<T>(in)) {}
 #endif
 		operator T() const { return c; }
 		void operator=(int t) { c=static_cast<T>(t); }


### PR DESCRIPTION
這個寫法一直都違反標準
只是以前編譯器沒有嚴查
C++20開始編譯器嚴查就會報錯

@mercury233 