### PR TITLE
fix CGUIScrollBar TrayClick

### DIFF
--- a/source/Irrlicht/CGUIScrollBar.cpp
+++ b/source/Irrlicht/CGUIScrollBar.cpp
@@ -21,9 +21,9 @@ CGUIScrollBar::CGUIScrollBar(bool horizontal, IGUIEnvironment* environment,
 				core::rect<s32> rectangle, bool noclip)
 	: IGUIScrollBar(environment, parent, id, rectangle), UpButton(0),
 	DownButton(0), Dragging(false), Horizontal(horizontal),
-	DraggedBySlider(false), TrayClick(false), Pos(0), DrawPos(0),
-	DrawHeight(0), Min(0), Max(100), SmallStep(10), LargeStep(50), DesiredPos(0),
-	LastChange(0), DrawBackground(true)
+	DraggedBySlider(false), Pos(0), DrawPos(0),
+	DrawHeight(0), Min(0), Max(100), SmallStep(10), LargeStep(50),
+	DrawBackground(true)
 {
 	#ifdef _DEBUG
 	setDebugName("CGUIScrollBar");
@@ -160,8 +160,26 @@ bool CGUIScrollBar::OnEvent(const SEvent& event)
 				{
 					Dragging = true;
 					DraggedBySlider = SliderRect.isPointInside(p);
-					TrayClick = !DraggedBySlider;
-					DesiredPos = getPosFromMousePos(p);
+					if (!DraggedBySlider)
+					{
+						const s32 desiredPos = getPosFromMousePos(p);
+						const s32 oldPos = Pos;
+						if (desiredPos >= Pos + LargeStep)
+							setPos(Pos + LargeStep);
+						else if (desiredPos <= Pos - LargeStep)
+							setPos(Pos - LargeStep);
+						else
+							setPos(desiredPos);
+						if (Pos != oldPos && Parent)
+						{
+							SEvent newEvent;
+							newEvent.EventType = EET_GUI_EVENT;
+							newEvent.GUIEvent.Caller = this;
+							newEvent.GUIEvent.Element = 0;
+							newEvent.GUIEvent.EventType = EGET_SCROLL_BAR_CHANGED;
+							Parent->OnEvent(newEvent);
+						}
+					}
 					return true;
 				}
 				break;
@@ -182,46 +200,23 @@ bool CGUIScrollBar::OnEvent(const SEvent& event)
 				if ( event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP )
 					Dragging = false;
 
-				const s32 newPos = getPosFromMousePos(p);
-				const s32 oldPos = Pos;
-
-				if (!DraggedBySlider)
-				{
-					if ( isInside )
-					{
-						DraggedBySlider = SliderRect.isPointInside(p);
-						TrayClick = !DraggedBySlider;
-					}
-
-					if (DraggedBySlider)
-					{
-						setPos(newPos);
-					}
-					else
-					{
-						TrayClick = false;
-						if (event.MouseInput.Event == EMIE_MOUSE_MOVED)
-							return isInside;
-					}
-				}
+				if (!DraggedBySlider && isInside)
+					DraggedBySlider = SliderRect.isPointInside(p);
 
 				if (DraggedBySlider)
 				{
+					const s32 newPos = getPosFromMousePos(p);
+					const s32 oldPos = Pos;
 					setPos(newPos);
-				}
-				else
-				{
-					DesiredPos = newPos;
-				}
-
-				if (Pos != oldPos && Parent)
-				{
-					SEvent newEvent;
-					newEvent.EventType = EET_GUI_EVENT;
-					newEvent.GUIEvent.Caller = this;
-					newEvent.GUIEvent.Element = 0;
-					newEvent.GUIEvent.EventType = EGET_SCROLL_BAR_CHANGED;
-					Parent->OnEvent(newEvent);
+					if (Pos != oldPos && Parent)
+					{
+						SEvent newEvent;
+						newEvent.EventType = EET_GUI_EVENT;
+						newEvent.GUIEvent.Caller = this;
+						newEvent.GUIEvent.Element = 0;
+						newEvent.GUIEvent.EventType = EGET_SCROLL_BAR_CHANGED;
+						Parent->OnEvent(newEvent);
+					}
 				}
 				return isInside;
 			} break;
@@ -236,36 +231,6 @@ bool CGUIScrollBar::OnEvent(const SEvent& event)
 	}
 
 	return IGUIElement::OnEvent(event);
-}
-
-void CGUIScrollBar::OnPostRender(u32 timeMs)
-{
-	if (Dragging && !DraggedBySlider && TrayClick && timeMs > LastChange + 200)
-	{
-		LastChange = timeMs;
-
-		const s32 oldPos = Pos;
-
-		if (DesiredPos >= Pos + LargeStep)
-			setPos(Pos + LargeStep);
-		else
-		if (DesiredPos <= Pos - LargeStep)
-			setPos(Pos - LargeStep);
-		else
-		if (DesiredPos >= Pos - LargeStep && DesiredPos <= Pos + LargeStep)
-			setPos(DesiredPos);
-
-		if (Pos != oldPos && Parent)
-		{
-			SEvent newEvent;
-			newEvent.EventType = EET_GUI_EVENT;
-			newEvent.GUIEvent.Caller = this;
-			newEvent.GUIEvent.Element = 0;
-			newEvent.GUIEvent.EventType = EGET_SCROLL_BAR_CHANGED;
-			Parent->OnEvent(newEvent);
-		}
-	}
-
 }
 
 //! draws the element and its children

--- a/source/Irrlicht/CGUIScrollBar.cpp
+++ b/source/Irrlicht/CGUIScrollBar.cpp
@@ -164,12 +164,7 @@ bool CGUIScrollBar::OnEvent(const SEvent& event)
 					{
 						const s32 desiredPos = getPosFromMousePos(p);
 						const s32 oldPos = Pos;
-						if (desiredPos >= Pos + LargeStep)
-							setPos(Pos + LargeStep);
-						else if (desiredPos <= Pos - LargeStep)
-							setPos(Pos - LargeStep);
-						else
-							setPos(desiredPos);
+						setPos(desiredPos);
 						if (Pos != oldPos && Parent)
 						{
 							SEvent newEvent;

--- a/source/Irrlicht/CGUIScrollBar.h
+++ b/source/Irrlicht/CGUIScrollBar.h
@@ -34,8 +34,6 @@ namespace gui
 		//! draws the element and its children
 		virtual void draw() IRR_OVERRIDE;
 
-		virtual void OnPostRender(u32 timeMs) IRR_OVERRIDE;
-
 
 		//! gets the maximum value of the scrollbar.
 		virtual s32 getMax() const IRR_OVERRIDE;
@@ -113,7 +111,6 @@ namespace gui
 		bool Dragging;
 		bool Horizontal;
 		bool DraggedBySlider;
-		bool TrayClick;
 		s32 Pos;
 		s32 DrawPos;
 		s32 DrawHeight;
@@ -121,8 +118,6 @@ namespace gui
 		s32 Max;
 		s32 SmallStep;
 		s32 LargeStep;
-		s32 DesiredPos;
-		u32 LastChange;
 		video::SColor CurrentIconColor;
 		bool DrawBackground;
 


### PR DESCRIPTION
`OnPostRender` is called during the rendering process. This stage generally should not dispatch events, and it definitely should not process events. If GUI controls are added or removed while handling events, it may invalidate the iterator used by `IGUIElement::OnPostRender`. In addition, developers would not expect GUI event handling and rendering to occur simultaneously, and may therefore use mutexes for event handling and GUI rendering. In such cases, dispatching events from `OnPostRender` could result in double locking.

At present, the event dispatching in `CGUIScrollBar::OnPostRender` is the only occurrence of this pattern in the codebase, and it poses a real risk. `CGUIEnvironment::OnPostRender` also adds and removes controls, but the current implementation does not appear to introduce any actual risk.

The event dispatching in `CGUIScrollBar::OnPostRender` currently exists to implement the behavior where clicking on the empty area of the scrollbar gradually moves the slider toward the clicked position. After this change, clicking on the empty area of the scrollbar will immediately move the slider directly to the clicked position.
